### PR TITLE
feat: migrate hosting to AWS (S3 + CloudFront) + add full-viewport 404 + fix EmailJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ dist/
 .env
 .env.*
 *.local
+aws-vars.sh

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" href="/favicon.ico">
     <title>OIDSI-PNW | Ile Iwori-Bogbe Seattle Chapter</title>
     <meta name="description" content="OIDSI-PNW (Seattle Chapter, Ile Iwori-Bogbe) — a community hub for events, resources, and cultural programming." />
-    <meta name="keywords" content="OIDSI-PNW, Seattle, Ile Iwori-Bogbe, community, cultural events, spiritual, programming" />
+    <meta name="keywords" content="OIDSI-PNW, Seattle, Ile Iwori-Bogbe, community, cultural events, IFA" />
     <meta name="author" content="Quinise Ercolano" />
 
     <!-- Google Fonts -->

--- a/router/router.ts
+++ b/router/router.ts
@@ -36,7 +36,13 @@ const routes = [
     name: 'Gallery',
     component: () => import('@/views/Gallery.vue'),
     meta: { title: 'Gallery • Ile Iwori-Bogbe' }
-  }
+  },
+  {
+    path: '/:pathMatch(.*)*', 
+    name: 'NotFound', 
+    component: () => import('@/views/NotFound.vue'),
+    meta: { title: 'Page Not Found • Ile Iwori-Bogbe' }
+  },
 ]
 
 const router = createRouter({

--- a/src/composables/useContactForm.ts
+++ b/src/composables/useContactForm.ts
@@ -1,6 +1,6 @@
 // src/composables/useContactForm.ts
-import { ref, reactive } from 'vue'
 import emailjs from '@emailjs/browser'
+import { reactive, ref } from 'vue'
 
 export function useContactForm() {
   const formEl = ref<HTMLFormElement | null>(null)
@@ -14,7 +14,6 @@ export function useContactForm() {
     message: false,
   })
 
-  // Used by EmailJS templates as a tracking number
   const contactNumber = Math.floor(Math.random() * 1_000_000)
     .toString()
     .padStart(6, '0')
@@ -48,7 +47,6 @@ export function useContactForm() {
     touch('name')
     touch('email')
     touch('message')
-    // Ensure a global, visible error banner appears
     status.value = { type: 'error', message: 'Please fix the highlighted fields.' }
   }
 
@@ -71,7 +69,6 @@ export function useContactForm() {
       return
     }
 
-    // Native validity gate
     if (!form.checkValidity()) {
       form.classList.add('was-validated')
       onInvalid()

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,0 +1,24 @@
+<template>
+  <main class="d-flex align-items-center justify-content-center text-center flex-grow-1 notfound">
+    <div class="container py-5">
+      <div class="mx-auto" style="max-width: 720px;">
+        <div class="display-1 fw-bold text-primary">404</div>
+        <h1 class="h2 fw-semibold mt-3">Page not found</h1>
+        <p class="text-muted mt-2">
+          The page you’re looking for doesn’t exist or may have moved.
+        </p>
+
+        <div class="d-flex gap-3 justify-content-center mt-4">
+          <RouterLink to="/" class="btn btn-primary px-4">Go home</RouterLink>
+          <RouterLink to="/contact" class="btn btn-outline-primary px-4">Contact us</RouterLink>
+        </div>
+      </div>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts"></script>
+
+<style scoped>
+  .notfound { min-height: 100dvh; }
+</style>


### PR DESCRIPTION
Infra/Hosting
- Move static hosting from Firebase to AWS: S3 (private) behind CloudFront with OAC.
- Configure SPA fallback at the CDN: 403/404 -> /index.html (200), default root = index.html.
- Set up production domain via Squarespace CNAME (www.oidsi-pnw.com) and ACM cert (us-east-1).
- (Ops note) Enabled CloudFront standard logs to S3 and set cache invalidation on deploy.

CI/CD
- Build with Node 20, sync dist/ to s3://oidsi-pnw-site-prod, then cloudfront invalidation.

App/UI
- Add NotFound.vue and a catch-all route `/:pathMatch(.*)*` so unknown paths render a styled 404.
- Make layout full-height; keep navbar/footer outside <router-view> so they render on 404.
- 404 page matches site styles and fills the viewport.

Contact form
- Adjusted environment variable with incorrect value that prevented form from submitting

Cleanup
- Remove Firebase Hosting artifacts (firebase.json, .firebaserc, firebase-tools).
- Add/refresh .gitignore entries for local helpers.